### PR TITLE
Updated h3 to v2

### DIFF
--- a/packages/h3/package.json
+++ b/packages/h3/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/supertest": "^6.0.3",
-    "h3": "^1.15.4",
+    "h3": "^2.0.1-rc.5",
     "publint": "catalog:",
     "supertest": "^7.1.4",
     "tsdown": "catalog:",


### PR DESCRIPTION
### Description

I tested `@intlify/h3` with h3 v2 and it seems to be working, but I saw the dependency was still h3 v1.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to maintain compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->